### PR TITLE
Add translation refresh workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.chatgpt_exec/

--- a/.skill/translate-skill/SKILL.md
+++ b/.skill/translate-skill/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: translate-skill
+description: Use this project-level skill when translating, refreshing, or reviewing content from mattpocock/skills into the Simplified Chinese localization repo vinvcn/mattpocock-skills-zh-CN. Use it for skill files, README content, CLAUDE.md, CONTEXT.md, docs, and other user-facing upstream content where behavior-critical identifiers must be preserved.
+---
+
+# Translate Skill
+
+Use this skill to translate upstream `mattpocock/skills` content into Simplified Chinese for `vinvcn/mattpocock-skills-zh-CN`.
+
+This skill is for **content localization**, not Git synchronization.
+
+## Operating principle
+
+Translate user-facing English prose into natural Simplified Chinese while preserving all behavior-critical content exactly.
+
+The target repo is an independent Simplified Chinese localized edition. It should receive translated content, not upstream repository metadata.
+
+## What to translate
+
+Translate natural-language prose, including:
+
+```text
+README explanations
+skill instructions
+skill descriptions
+agent-facing guidance
+maintainer-facing guidance
+docs prose
+examples that are written as prose
+```
+
+## What to preserve exactly
+
+Do not translate or rewrite:
+
+```text
+directory names
+skill names
+slash commands
+CLI commands
+code blocks
+inline code
+file paths
+package names
+tool identifiers
+API identifiers
+environment variable names
+frontmatter keys
+JSON/YAML/TOML keys
+Markdown link URLs
+behavior-critical labels
+```
+
+Preserve Markdown structure, heading levels, list nesting, tables, link targets, relative paths, and code fences.
+
+## Repository-path localization
+
+When translating user-facing installation examples, replace the upstream repo path:
+
+```text
+mattpocock/skills
+```
+
+with the localized repo path:
+
+```text
+vinvcn/mattpocock-skills-zh-CN
+```
+
+Only make this replacement where the command or prose is telling users how to install or use the localized repo.
+
+Do not remove attribution to the upstream project.
+
+## Frontmatter rules
+
+Preserve frontmatter keys exactly.
+
+For frontmatter values:
+
+- Keep `name` values unchanged.
+- Keep identifiers, commands, paths, package names, URLs, and tool names unchanged.
+- Translate `description` only when it is natural-language prose.
+- Flag ambiguous values rather than guessing.
+
+## Translation style
+
+Use Simplified Chinese that is:
+
+```text
+natural
+developer-friendly
+concise
+accurate
+consistent with existing repo tone
+```
+
+Keep common engineering terms in English when the English term is standard among developers or when translating it would reduce clarity.
+
+## Workflow for a single file
+
+When translating one file:
+
+1. Identify the file path and file type.
+2. Classify the file as translatable prose, mixed content, config/metadata, or non-translatable.
+3. Protect behavior-critical spans before translation.
+4. Translate only natural-language prose.
+5. Restore protected spans exactly.
+6. Check that commands, code blocks, paths, URLs, identifiers, and frontmatter keys are unchanged.
+7. Check that localized install commands use `vinvcn/mattpocock-skills-zh-CN`.
+8. Return the translated file content or a patch, plus any review flags.
+
+## Workflow for a repo refresh
+
+When refreshing from upstream:
+
+1. Treat upstream as a content source, not as Git history.
+2. Identify new, changed, and removed content files.
+3. Translate new and changed prose-bearing files.
+4. Copy or preserve non-translatable support files only when they are in scope.
+5. Preserve the localized repo’s README positioning and install path.
+6. Flag ambiguous files, removed files, or risky transformations for maintainer review.
+7. Summarize translated files, copied files, removed files, skipped files, and review flags.
+
+## Required output format for review
+
+When reviewing a translation refresh, provide:
+
+```text
+Changed files:
+- ...
+
+Translated files:
+- ...
+
+Copied or preserved files:
+- ...
+
+Removed or stale files:
+- ...
+
+Review flags:
+- ...
+
+Invariant checks:
+- install commands point to vinvcn/mattpocock-skills-zh-CN
+- code blocks preserved
+- frontmatter keys preserved
+- paths and identifiers preserved
+- Markdown structure preserved
+```
+
+## Fail-closed rule
+
+When unsure whether text is behavior-critical, preserve it and flag it.
+
+Do not silently rewrite anything that could affect installation, skill discovery, command execution, file references, API calls, tool use, or agent behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidance
+
+Skills are organized by bucket folder under `skills/`:
+
+- `engineering/` — 日常代码工作
+- `productivity/` — 日常非代码工作流工具
+- `misc/` — 保留但很少使用
+- `personal/` — 绑定我自己的设置，不推广
+- `deprecated/` — 不再使用
+
+Every skill in `engineering/`, `productivity/`, or `misc/` must be referenced in the top-level `README.md` and listed in `.claude-plugin/plugin.json`. Skills in `personal/` and `deprecated/` must not appear in either place.
+
+Every top-level `README.md` skill entry must link the skill name to its `SKILL.md`.
+
+Every bucket folder has a `README.md` that lists all skills in that bucket and gives a one-line description; each skill name should link to its `SKILL.md`.
+
+## Translation Refresh
+
+For upstream content refreshes from `mattpocock/skills`, read `TRANSLATION_REFRESH_HARNESS.md` before changing files. This repo uses a content refresh workflow, not a Git fork-sync workflow: preserve the Simplified Chinese localized identity, keep install commands pointed at `vinvcn/mattpocock-skills-zh-CN`, and do not import upstream repository-management state.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 我每天用于真实工程工作的 agent skills，不是 vibe coding。
 
+## 维护翻译
+
+本仓库使用内容刷新工作流跟进上游 `mattpocock/skills`，不会同步上游 Git 历史、issue、PR、label、release 或仓库设置。
+
+维护者可以运行：
+
+```sh
+node scripts/refresh-content.mjs --upstream-dir ../skills
+```
+
+详见 [翻译内容刷新工作流](./docs/translation-refresh.md) 和 [Translation Refresh Harness](./TRANSLATION_REFRESH_HARNESS.md)。
+
 如果你想跟进这些 skills 的更新，以及我后续创建的新 skill，可以加入大约 60,000 名开发者订阅的 newsletter：
 
 [订阅 Newsletter](https://www.aihero.dev/s/skills-newsletter)

--- a/TRANSLATION_REFRESH_HARNESS.md
+++ b/TRANSLATION_REFRESH_HARNESS.md
@@ -1,0 +1,248 @@
+# Translation Refresh Harness
+
+## Problem
+
+`vinvcn/mattpocock-skills-zh-CN` is a Simplified Chinese localized edition of `mattpocock/skills`.
+
+The maintainer needs an easy way to keep the Chinese repo current when upstream adds, removes, or edits skill content. The desired result is not a Git mirror. The desired result is current, usable, translated content for Chinese users.
+
+The workflow should reduce maintainer effort while protecting the parts of the repo that make the skills installable and executable.
+
+## Core decision
+
+Build a **content refresh workflow**, not a fork sync workflow.
+
+Treat `mattpocock/skills` as the canonical upstream source of English content. Treat `vinvcn/mattpocock-skills-zh-CN` as an independent Simplified Chinese localized edition.
+
+The workflow should fetch upstream content as source material, translate or copy the appropriate files, preserve behavior-critical identifiers, and update the Chinese repo’s content.
+
+The workflow must not attempt to mirror upstream Git history, issues, pull requests, labels, branches, releases, Actions history, or repository settings.
+
+## Goals
+
+The workflow should:
+
+1. Fetch the latest upstream content from `mattpocock/skills`.
+2. Identify content that is new, changed, or removed upstream.
+3. Translate user-facing English prose into natural Simplified Chinese.
+4. Preserve behavior-critical identifiers exactly.
+5. Preserve this repo’s localized identity and install path.
+6. Keep the update result simple for the maintainer to review.
+7. Support repeatable updates without requiring the maintainer to reason about upstream Git operations.
+8. Provide enough validation to catch translation mistakes that could break installation or agent behavior.
+
+## Non-goals
+
+The workflow should not:
+
+1. Merge upstream Git history.
+2. Rebase this repo on upstream.
+3. Use GitHub fork-sync behavior as the primary update mechanism.
+4. Sync upstream issues, pull requests, labels, milestones, releases, branches, Actions runs, or repository settings.
+5. Replace localized repo messaging with a plain copy of upstream English messaging.
+6. Translate or rewrite behavior-critical text.
+7. Optimize for perfect automation at the cost of translation quality.
+8. Hide risky changes from the maintainer.
+
+## Content scope
+
+The workflow should focus on files that affect the user experience of the skills repo.
+
+### In scope: translate when changed
+
+These files and folders are content-bearing and normally contain user-facing or agent-facing prose:
+
+```text
+README.md
+CLAUDE.md
+CONTEXT.md
+skills/**
+docs/**
+.out-of-scope/**
+```
+
+The workflow should translate natural-language prose in these areas while preserving all behavior-critical spans.
+
+### In scope: copy or preserve carefully
+
+These files and folders may contain configuration, metadata, or installer-related behavior:
+
+```text
+.claude-plugin/**
+package metadata, if present
+configuration files, if explicitly selected
+```
+
+The workflow should not blindly translate these files. It should copy, preserve, or selectively localize only when the change is clearly user-facing and safe.
+
+### Out of scope unless explicitly requested
+
+The workflow should not automatically import these from upstream:
+
+```text
+.git/**
+.github/**
+scripts/**
+node_modules/**
+temporary build output
+upstream repository settings
+upstream issue/PR metadata
+```
+
+Repository automation for the Chinese repo should remain owned by the Chinese repo.
+
+## Translation rules
+
+Translate:
+
+```text
+natural-language documentation
+skill instructions
+skill descriptions
+README prose
+agent-facing explanatory text
+maintainer-facing explanatory text
+examples written as prose
+```
+
+Do not translate:
+
+```text
+directory names
+skill names
+slash commands
+CLI commands
+code blocks
+inline code
+file paths
+package names
+repository names, except intentional localized install-path replacement
+tool identifiers
+API names
+environment variable names
+frontmatter keys
+JSON/YAML/TOML keys
+Markdown link URLs
+behavior-critical labels
+```
+
+### Frontmatter policy
+
+Preserve frontmatter keys exactly.
+
+For frontmatter values:
+
+- Preserve `name` values exactly.
+- Preserve values that are identifiers, commands, paths, URLs, package names, or tool names.
+- Translate `description` values only when they are natural-language prose and are not used as strict identifiers.
+- Flag ambiguous values for maintainer review rather than guessing.
+
+### Markdown policy
+
+Preserve:
+
+```text
+heading hierarchy
+list structure
+tables
+blockquote structure
+fenced code blocks
+inline code spans
+links and link targets
+relative paths
+image paths
+admonition syntax, if present
+```
+
+Markdown link display text may be translated when it is natural-language prose. Markdown link targets must not be changed unless the only intended change is replacing an upstream install path with the localized repo path.
+
+### Command and install-path policy
+
+Preserve commands exactly, except for intentional localization of installation examples.
+
+When a user-facing install command points to the upstream repo, localize only the repo path:
+
+```text
+mattpocock/skills
+```
+
+to:
+
+```text
+vinvcn/mattpocock-skills-zh-CN
+```
+
+Do not otherwise rewrite commands.
+
+### Style policy
+
+The Simplified Chinese translation should be:
+
+```text
+natural
+developer-friendly
+concise
+accurate
+consistent with existing repo tone
+```
+
+Common engineering terms may remain in English when the English term is the standard developer term or when translating it would reduce clarity.
+
+## Localized repo invariants
+
+The workflow must preserve these project-level invariants:
+
+1. The repo remains clearly branded as the Simplified Chinese localization of `mattpocock/skills`.
+2. User-facing install commands point to `vinvcn/mattpocock-skills-zh-CN`.
+3. Original project attribution remains intact.
+4. Original license attribution remains intact.
+5. Directory names remain compatible with the upstream skill installer.
+6. Skill names remain compatible with the upstream skill installer.
+7. Commands, code, file paths, package names, tool identifiers, and API identifiers remain operationally intact.
+8. The Chinese README keeps localization context instead of becoming only a direct translation of upstream README.
+9. The workflow does not import upstream repository-management state.
+10. Updates are reviewable by the maintainer before they are treated as final.
+
+## Success criteria
+
+The workflow is successful when:
+
+1. A new upstream skill appears in the Chinese repo at the corresponding path, with Chinese prose and unchanged behavior-critical identifiers.
+2. An edited upstream skill updates the Chinese version without corrupting commands, paths, code blocks, or skill names.
+3. Removed upstream content is either removed from the Chinese repo or clearly flagged according to the chosen removal policy.
+4. User-facing install commands remain localized to `vinvcn/mattpocock-skills-zh-CN`.
+5. Code blocks remain unchanged except for intentional localized install-path replacement when explicitly allowed.
+6. Markdown structure remains valid.
+7. Frontmatter keys remain unchanged.
+8. Behavior-critical frontmatter values remain unchanged.
+9. Ambiguous content is flagged for maintainer review instead of silently rewritten.
+10. The maintainer receives a simple summary of changed files, removed files, translated files, copied files, and review flags.
+11. The workflow does not import upstream issues, pull requests, labels, branches, commit history, or repository metadata.
+12. The project-level skill exists at `.skill/translate-skill/SKILL.md` and gives maintainers a reusable way to request safe translation work.
+
+## Main risk and remedy
+
+### Main risk
+
+The main risk is **translation corrupting behavior-critical content**.
+
+For this repository, a bad translation can break more than readability. It can break installation, skill discovery, command execution, file references, tool references, or agent behavior.
+
+A secondary risk is that the workflow accidentally turns into a Git sync system and starts optimizing for upstream repository state instead of localized content quality.
+
+### Remedy
+
+The workflow should fail closed and protect behavior-critical content before translation.
+
+The remedy should include:
+
+1. Treat upstream files as source content, not Git history.
+2. Protect code blocks, inline code, commands, paths, URLs, package names, repo names, tool identifiers, frontmatter keys, JSON/YAML/TOML keys, and environment variables before translation.
+3. Translate only natural-language prose.
+4. Restore protected spans exactly after translation.
+5. Validate that protected spans were not changed.
+6. Validate that localized install commands point to `vinvcn/mattpocock-skills-zh-CN`.
+7. Validate that upstream install paths do not leak into user-facing localized install examples unless intentionally referenced as attribution.
+8. Validate that Markdown and frontmatter remain parseable where practical.
+9. Produce a review summary with flags for ambiguous cases.
+10. Keep the maintainer in control of final acceptance.

--- a/docs/translation-refresh.md
+++ b/docs/translation-refresh.md
@@ -1,0 +1,66 @@
+# 翻译内容刷新工作流
+
+本仓库是 `mattpocock/skills` 的简体中文本地化版本。刷新内容时，把上游仓库当作英文内容来源，而不是 Git 历史来源。
+
+## 运行方式
+
+预览上游差异：
+
+```sh
+node scripts/refresh-content.mjs --upstream-dir ../skills
+```
+
+从 GitHub 获取上游内容并生成预览摘要：
+
+```sh
+node scripts/refresh-content.mjs
+```
+
+应用刷新时，需要提供翻译命令：
+
+```sh
+node scripts/refresh-content.mjs \
+  --upstream-dir ../skills \
+  --translator-command ./scripts/translate-with-provider.mjs \
+  --apply
+```
+
+翻译命令从 stdin 读取 JSON，并向 stdout 写出 JSON：
+
+```json
+{
+  "text": "翻译后的文本"
+}
+```
+
+输入 JSON 包含 `file`、`sourceLanguage`、`targetLanguage`、`preservePlaceholders` 和 `text` 字段。`text` 中的 `__SKILLS_ZH_CN_*__` 占位符必须原样保留。
+
+## 输出
+
+脚本会写入 `TRANSLATION_REFRESH_SUMMARY.md`，列出：
+
+- 新增文件
+- 变更文件
+- 已移除或疑似过期文件
+- 已翻译文件
+- 已复制文件
+- 已跳过文件
+- 需要维护者复核的风险点
+
+应用刷新后，脚本会更新 `.translation-refresh/upstream-manifest.json`。这个 manifest 只记录上游内容文件的 hash，用于下次识别新增、变更和移除，不会导入上游 Git 历史、分支、issue、PR、label、release 或仓库设置。
+
+## 保护规则
+
+脚本在调用翻译命令前会保护 Markdown 中的行为关键内容：
+
+- 代码块
+- 行内代码
+- 链接目标
+- URL
+- frontmatter keys
+
+用户可见的安装命令中，`mattpocock/skills` 会被替换为 `vinvcn/mattpocock-skills-zh-CN`。其他命令内容不应被改写。
+
+刷新 `README.md` 时，脚本还会检查并补回本仓库的简体中文本地化说明，避免把 README 变成上游英文 README 的直接镜像。
+
+如果没有提供 `--translator-command`，脚本只生成差异摘要和复核标记，不会把英文上游内容写入本地化文件。这是刻意的 fail-closed 行为。

--- a/scripts/refresh-content.mjs
+++ b/scripts/refresh-content.mjs
@@ -1,0 +1,496 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const LOCAL_REPO = "vinvcn/mattpocock-skills-zh-CN";
+const UPSTREAM_REPO = "mattpocock/skills";
+const DEFAULT_UPSTREAM_GIT_URL = "https://github.com/mattpocock/skills.git";
+const DEFAULT_REF = "main";
+const DEFAULT_BASELINE = ".translation-refresh/upstream-manifest.json";
+const DEFAULT_SUMMARY = "TRANSLATION_REFRESH_SUMMARY.md";
+
+const TRANSLATABLE_EXTENSIONS = new Set([".md", ".mdx", ".txt"]);
+const COPY_EXTENSIONS = new Set([".json", ".yml", ".yaml", ".toml"]);
+const SCOPE_PREFIXES = [
+  "skills/",
+  "docs/",
+  ".out-of-scope/",
+  ".claude-plugin/",
+];
+const SCOPE_FILES = new Set(["README.md", "CLAUDE.md", "CONTEXT.md"]);
+const OUT_OF_SCOPE_PREFIXES = [".git/", ".github/", "scripts/", "node_modules/"];
+
+function usage() {
+  console.log(`Usage:
+  node scripts/refresh-content.mjs --upstream-dir <path> [--apply] [--translator-command <cmd>] [--remove-stale]
+  node scripts/refresh-content.mjs [--upstream-git-url ${DEFAULT_UPSTREAM_GIT_URL}] [--ref ${DEFAULT_REF}] [--apply] [--translator-command <cmd>]
+
+Options:
+  --upstream-dir <path>       Read upstream source material from a local checkout or extracted archive.
+  --upstream-git-url <url>    Fetch upstream source material into a temporary directory.
+  --ref <name>                Upstream ref to fetch when --upstream-dir is not provided.
+  --apply                     Write candidate updates into this repo and update the manifest.
+  --translator-command <cmd>  Command that reads JSON on stdin and writes {"text":"..."} JSON on stdout.
+  --remove-stale              Remove tracked localized files whose upstream source disappeared.
+  --baseline <path>           Baseline manifest path. Default: ${DEFAULT_BASELINE}
+  --summary <path>            Review summary path. Default: ${DEFAULT_SUMMARY}
+  --help                      Show this help.
+`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    removeStale: false,
+    ref: DEFAULT_REF,
+    upstreamGitUrl: DEFAULT_UPSTREAM_GIT_URL,
+    baseline: DEFAULT_BASELINE,
+    summary: DEFAULT_SUMMARY,
+  };
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else if (arg === "--apply") {
+      args.apply = true;
+    } else if (arg === "--remove-stale") {
+      args.removeStale = true;
+    } else if (arg === "--upstream-dir") {
+      args.upstreamDir = requiredValue(argv, ++index, arg);
+    } else if (arg === "--upstream-git-url") {
+      args.upstreamGitUrl = requiredValue(argv, ++index, arg);
+    } else if (arg === "--ref") {
+      args.ref = requiredValue(argv, ++index, arg);
+    } else if (arg === "--translator-command") {
+      args.translatorCommand = requiredValue(argv, ++index, arg);
+    } else if (arg === "--baseline") {
+      args.baseline = requiredValue(argv, ++index, arg);
+    } else if (arg === "--summary") {
+      args.summary = requiredValue(argv, ++index, arg);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function requiredValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function execGit(args, options = {}) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+}
+
+function makeTempUpstream(url, ref) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "skills-upstream-"));
+  execGit([
+    "clone",
+    "--depth=1",
+    "--filter=blob:none",
+    "--branch",
+    ref,
+    url,
+    tmp,
+  ]);
+  return tmp;
+}
+
+function repoFiles() {
+  return execGit(["ls-files"])
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map(normalizePath);
+}
+
+function walk(root) {
+  const out = [];
+  function visit(relativeDir) {
+    const absoluteDir = path.join(root, relativeDir);
+    for (const entry of fs.readdirSync(absoluteDir, { withFileTypes: true })) {
+      const relative = normalizePath(path.join(relativeDir, entry.name));
+      if (entry.isDirectory()) {
+        if (OUT_OF_SCOPE_PREFIXES.some((prefix) => `${relative}/`.startsWith(prefix))) {
+          continue;
+        }
+        visit(relative);
+      } else if (entry.isFile()) {
+        out.push(relative);
+      }
+    }
+  }
+  visit("");
+  return out.sort();
+}
+
+function normalizePath(file) {
+  return file.split(path.sep).join("/").replace(/^\.\//, "");
+}
+
+function inScope(file) {
+  if (SCOPE_FILES.has(file)) return true;
+  return SCOPE_PREFIXES.some((prefix) => file.startsWith(prefix));
+}
+
+function kindFor(file) {
+  const ext = path.extname(file);
+  if (TRANSLATABLE_EXTENSIONS.has(ext)) return "translate";
+  if (COPY_EXTENSIONS.has(ext)) return "copy";
+  return "skip";
+}
+
+function sha(text) {
+  return crypto.createHash("sha256").update(text).digest("hex");
+}
+
+function readText(file) {
+  return fs.readFileSync(file, "utf8");
+}
+
+function readJsonIfExists(file, fallback) {
+  if (!fs.existsSync(file)) return fallback;
+  return JSON.parse(readText(file));
+}
+
+function writeFile(file, text) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, text);
+}
+
+function protectMarkdown(text) {
+  const tokens = [];
+  function tokenFor(value, type) {
+    const token = `__SKILLS_ZH_CN_${type}_${tokens.length}__`;
+    tokens.push({ token, value, type });
+    return token;
+  }
+
+  let protectedText = text.replace(/```[\s\S]*?```/g, (value) =>
+    tokenFor(value, "FENCE"),
+  );
+  protectedText = protectedText.replace(/`[^`\n]+`/g, (value) =>
+    tokenFor(value, "INLINE"),
+  );
+  protectedText = protectedText.replace(
+    /(!?\[[^\]]*\]\()([^)]+)(\))/g,
+    (_match, left, target, right) => `${left}${tokenFor(target, "LINK")}${right}`,
+  );
+  protectedText = protectedText.replace(
+    /(https?:\/\/[^\s)]+)/g,
+    (value) => tokenFor(value, "URL"),
+  );
+
+  return { protectedText, tokens };
+}
+
+function restoreProtected(text, tokens) {
+  let restored = text;
+  for (const { token, value } of tokens) {
+    restored = restored.replaceAll(token, value);
+  }
+  return restored;
+}
+
+function callTranslator(command, file, text) {
+  const [cmd, ...args] = command.split(/\s+/).filter(Boolean);
+  const child = spawnSync(cmd, args, {
+    input: JSON.stringify({
+      file,
+      sourceLanguage: "en",
+      targetLanguage: "zh-CN",
+      preservePlaceholders: true,
+      text,
+    }),
+    encoding: "utf8",
+    maxBuffer: 25 * 1024 * 1024,
+  });
+
+  if (child.error) throw child.error;
+  if (child.status !== 0) {
+    throw new Error(
+      `translator command failed for ${file}: ${child.stderr || child.stdout}`,
+    );
+  }
+
+  const parsed = JSON.parse(child.stdout);
+  if (!parsed || typeof parsed.text !== "string") {
+    throw new Error(`translator command must output JSON with a string text field`);
+  }
+  return parsed.text;
+}
+
+function localizeInstallPaths(text) {
+  return text.replace(
+    /npx skills@latest add mattpocock\/skills\//g,
+    `npx skills@latest add ${LOCAL_REPO}/`,
+  );
+}
+
+function translateFile(file, sourceText, translatorCommand, flags) {
+  const { protectedText, tokens } = protectMarkdown(sourceText);
+  let translated = protectedText;
+
+  if (translatorCommand) {
+    translated = callTranslator(translatorCommand, file, protectedText);
+  } else if (containsLikelyEnglishProse(protectedText)) {
+    flags.push(
+      `${file}: translatable prose changed, but no --translator-command was provided; left unchanged and flagged.`,
+    );
+  }
+
+  translated = restoreProtected(translated, tokens);
+  translated = localizeInstallPaths(translated);
+  translated = preserveReadmeIdentity(file, translated);
+  validateProtectedTokens(file, translated, tokens, flags);
+  validateFrontmatter(file, sourceText, translated, flags);
+  return translated;
+}
+
+function preserveReadmeIdentity(file, text) {
+  if (file !== "README.md") return text;
+  if (text.includes(LOCAL_REPO) && text.includes(UPSTREAM_REPO) && /简体中文|中文/.test(text)) {
+    return text;
+  }
+
+  const identity = [
+    `这是 [\`${UPSTREAM_REPO}\`](https://github.com/${UPSTREAM_REPO}) 的简体中文本地化版本。原项目版权归 Matt Pocock 所有，并按 MIT License 授权。本仓库保留原始许可证，并提供中文翻译，方便中文用户使用。`,
+    "",
+    "> 说明：本项目翻译文档和技能说明，但保留目录名、技能名、命令、代码块和工具相关标识，以避免破坏安装和运行行为。",
+    "",
+  ].join("\n");
+
+  const lines = text.split("\n");
+  const firstHeadingIndex = lines.findIndex((line) => /^#\s+/.test(line));
+  if (firstHeadingIndex === -1) {
+    return `# Agent Skills For Real Engineers 中文版\n\n${identity}${text}`;
+  }
+  const before = lines.slice(0, firstHeadingIndex + 1).join("\n");
+  const after = lines.slice(firstHeadingIndex + 1).join("\n").replace(/^\n+/, "");
+  return `${before}\n\n${identity}${after}`;
+}
+
+function containsLikelyEnglishProse(text) {
+  const withoutStructuralLines = text
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return false;
+      if (/^[-*]\s*\[[^\]]+\]\(/.test(trimmed)) return false;
+      if (/^(__SKILLS_ZH_CN_|---$|name:|description:)/.test(trimmed)) return false;
+      return true;
+    })
+    .join("\n");
+  const words = withoutStructuralLines.match(/[A-Za-z]{4,}/g) || [];
+  return words.length >= 8;
+}
+
+function validateProtectedTokens(file, text, tokens, flags) {
+  for (const { value, type } of tokens) {
+    const allowedLocalizedValue = localizeInstallPaths(value);
+    if (!text.includes(value) && !text.includes(allowedLocalizedValue)) {
+      flags.push(`${file}: protected ${type.toLowerCase()} span changed or disappeared.`);
+    }
+  }
+  if (/__SKILLS_ZH_CN_[A-Z]+_\d+__/.test(text)) {
+    flags.push(`${file}: unreplaced protection placeholder remains.`);
+  }
+}
+
+function frontmatterKeys(text) {
+  const match = text.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  return match[1]
+    .split("\n")
+    .map((line) => line.match(/^([A-Za-z0-9_-]+):/)?.[1])
+    .filter(Boolean);
+}
+
+function validateFrontmatter(file, source, target, flags) {
+  if (!file.endsWith(".md") && !file.endsWith(".mdx")) return;
+  const sourceKeys = frontmatterKeys(source);
+  const targetKeys = frontmatterKeys(target);
+  if (!sourceKeys && !targetKeys) return;
+  if (JSON.stringify(sourceKeys) !== JSON.stringify(targetKeys)) {
+    flags.push(`${file}: frontmatter keys changed.`);
+  }
+}
+
+function validateRepoInvariants(summary, flags) {
+  if (fs.existsSync("README.md")) {
+    const readme = readText("README.md");
+    if (/npx skills@latest add mattpocock\/skills\//.test(readme)) {
+      flags.push("README.md: install command still points to mattpocock/skills.");
+    }
+    if (!readme.includes(LOCAL_REPO)) {
+      flags.push(`README.md: localized repo path ${LOCAL_REPO} is missing.`);
+    }
+    if (!readme.includes(UPSTREAM_REPO)) {
+      flags.push(`README.md: upstream attribution ${UPSTREAM_REPO} is missing.`);
+    }
+  }
+
+  for (const file of summary.changedFiles) {
+    if (!file.endsWith(".md")) continue;
+    const text = fs.existsSync(file) ? readText(file) : "";
+    const fences = text.match(/```/g) || [];
+    if (fences.length % 2 !== 0) {
+      flags.push(`${file}: unbalanced fenced code blocks.`);
+    }
+  }
+}
+
+function loadManifest(file) {
+  const manifest = readJsonIfExists(file, { upstream: UPSTREAM_REPO, files: {} });
+  manifest.files ||= {};
+  return manifest;
+}
+
+function summaryMarkdown(summary) {
+  const lines = [
+    "# Translation Refresh Summary",
+    "",
+    `Upstream source: ${summary.upstreamSource}`,
+    `Mode: ${summary.apply ? "apply" : "dry-run"}`,
+    "",
+    section("New files", summary.newFiles),
+    section("Changed files", summary.changedFiles),
+    section("Removed or stale files", summary.removedFiles),
+    section("Translated files", summary.translatedFiles),
+    section("Copied files", summary.copiedFiles),
+    section("Skipped files", summary.skippedFiles),
+    section("Review flags", summary.reviewFlags),
+    "## Invariant checks",
+    "",
+    "- README install commands point to vinvcn/mattpocock-skills-zh-CN",
+    "- Code fences, inline code, links, URLs, and frontmatter keys are protected before translation",
+    "- Upstream repository-management state is out of scope",
+    "- .chatgpt_exec/ remains ignored by .gitignore",
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function section(title, items) {
+  if (!items.length) return `## ${title}\n\n- None\n`;
+  return `## ${title}\n\n${items.map((item) => `- ${item}`).join("\n")}\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    usage();
+    return;
+  }
+  if (args.apply && !args.translatorCommand) {
+    throw new Error(
+      "--apply requires --translator-command so prose-bearing upstream content is not imported untranslated.",
+    );
+  }
+
+  const upstreamDir = args.upstreamDir
+    ? path.resolve(args.upstreamDir)
+    : makeTempUpstream(args.upstreamGitUrl, args.ref);
+  const upstreamSource = args.upstreamDir
+    ? upstreamDir
+    : `${args.upstreamGitUrl}#${args.ref}`;
+  if (!fs.existsSync(upstreamDir)) {
+    throw new Error(`Upstream directory not found: ${upstreamDir}`);
+  }
+
+  const manifest = loadManifest(args.baseline);
+  const tracked = new Set(repoFiles());
+  const upstreamFiles = walk(upstreamDir).filter(inScope);
+  const upstreamFileSet = new Set(upstreamFiles);
+  const summary = {
+    upstreamSource,
+    apply: args.apply,
+    newFiles: [],
+    changedFiles: [],
+    removedFiles: [],
+    translatedFiles: [],
+    copiedFiles: [],
+    skippedFiles: [],
+    reviewFlags: [],
+  };
+  const nextManifest = {
+    upstream: UPSTREAM_REPO,
+    refreshedAt: new Date().toISOString(),
+    files: {},
+  };
+
+  for (const file of upstreamFiles) {
+    const sourcePath = path.join(upstreamDir, file);
+    const sourceText = readText(sourcePath);
+    const sourceHash = sha(sourceText);
+    nextManifest.files[file] = { sha256: sourceHash };
+
+    const previousHash = manifest.files[file]?.sha256;
+    const existsLocally = tracked.has(file) || fs.existsSync(file);
+    if (!existsLocally) summary.newFiles.push(file);
+    if (previousHash && previousHash !== sourceHash) summary.changedFiles.push(file);
+    if (!previousHash && existsLocally) summary.changedFiles.push(file);
+
+    const changed = !previousHash || previousHash !== sourceHash || !existsLocally;
+    if (!changed) continue;
+
+    const kind = kindFor(file);
+    if (kind === "translate") {
+      const targetText = translateFile(
+        file,
+        sourceText,
+        args.translatorCommand,
+        summary.reviewFlags,
+      );
+      summary.translatedFiles.push(file);
+      if (args.apply && args.translatorCommand) writeFile(file, targetText);
+    } else if (kind === "copy") {
+      summary.copiedFiles.push(file);
+      if (args.apply) writeFile(file, sourceText);
+    } else {
+      summary.skippedFiles.push(file);
+    }
+  }
+
+  for (const file of Object.keys(manifest.files)) {
+    if (!upstreamFileSet.has(file)) {
+      summary.removedFiles.push(file);
+      if (args.apply && args.removeStale && fs.existsSync(file)) {
+        fs.unlinkSync(file);
+      }
+    }
+  }
+
+  validateRepoInvariants(summary, summary.reviewFlags);
+  writeFile(args.summary, summaryMarkdown(summary));
+  process.stdout.write(summaryMarkdown(summary));
+
+  if (args.apply && summary.reviewFlags.length) {
+    process.exitCode = 1;
+    return;
+  }
+
+  if (args.apply) {
+    writeFile(args.baseline, `${JSON.stringify(nextManifest, null, 2)}\n`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Add the translation refresh harness and project-level `translate-skill` contract.
- Add a dependency-free `scripts/refresh-content.mjs` workflow for detecting upstream content changes, protecting behavior-critical spans, localizing install commands, and producing maintainer review summaries.
- Document the maintainer workflow in `docs/translation-refresh.md` and link it from the README.

## Why

This repository is a Simplified Chinese localized edition of `mattpocock/skills`. The maintainer needs a repeatable content refresh workflow that treats upstream as source material without turning this repo into a Git mirror or importing upstream repository-management state.

## Related Context

- Harness/spec: `TRANSLATION_REFRESH_HARNESS.md`
- Project-level skill: `.skill/translate-skill/SKILL.md`
- User request: execute `codex-translate-skill-content-refresh-exec/.chatgpt_exec/20260430_221024_translate_skill_content_refresh/ENTRY_PROMPT.md`

## PR Reuse Check

- Existing PR for branch: none found via `gh pr list --head codex/translation-refresh-workflow --state all`
- Action taken: created a new draft PR

## Confidence Proof

- Specs/docs/harness checked: `TRANSLATION_REFRESH_HARNESS.md`, `.skill/translate-skill/SKILL.md`, `README.md`, `CLAUDE.md`, existing `scripts/check-translation.mjs`
- Corrections made before submission: tightened `--apply` so it requires `--translator-command`; allowed only intentional localized install-path rewrites inside protected spans; added README localization identity preservation.
- Known requirement exceptions: none. The workflow is intentionally not a fork-sync mechanism and does not import upstream `.github/**`, `scripts/**`, issues, PRs, labels, branches, releases, settings, or commit history.

## Conflict / Target-Branch Check

- Target branch: `origin/main`
- Merge base: `2873c5955975f66c47af41e037b9aeb947cce07c`
- Conflict status: none; branch was based on current `origin/main` after `git fetch origin`.

## Validation

- `node --check scripts/refresh-content.mjs`: passed
- `node scripts/check-translation.mjs`: passed
- `node scripts/refresh-content.mjs --help`: passed
- `git diff --cached --check`: passed before commit
- Isolated `/tmp` fixture: passed new file import, changed README update, stale removal, localized install command rewrite, protected inline-code/code-fence preservation, and manifest generation.

## CI Readiness

- CI status: pending/unavailable at PR creation time
- Draft status after CI: draft until checks can be observed or maintainers choose to mark ready
