### PR TITLE
Translate user-facing skill frontmatter fields

### DIFF
--- a/.skills/translate-skill/SKILL.md
+++ b/.skills/translate-skill/SKILL.md
@@ -23,6 +23,7 @@ Translate natural-language prose, including:
 README explanations
 skill instructions
 skill descriptions
+user-facing frontmatter prompts
 agent-facing guidance
 maintainer-facing guidance
 docs prose
@@ -75,12 +76,27 @@ Do not remove attribution to the upstream project.
 
 Preserve frontmatter keys exactly.
 
-For frontmatter values:
+Classify each frontmatter value by meaning, not just by field name:
 
 - Keep `name` values unchanged.
-- Keep identifiers, commands, paths, package names, URLs, and tool names unchanged.
-- Translate `description` only when it is natural-language prose.
+- Translate user-facing or agent-facing natural-language prose into Simplified Chinese. This
+  includes `description` and `argument-hint` values.
+- Keep identifiers, commands, paths, package names, URLs, tool names, booleans, numbers, and
+  other typed configuration values unchanged.
+- Within a translatable value, preserve embedded slash commands, inline code, placeholders,
+  paths, URLs, package names, tool names, and other behavior-critical spans exactly.
 - Flag ambiguous values rather than guessing.
+
+Example:
+
+```yaml
+---
+name: teach
+description: 在这个工作区中教用户一个新技能或概念。
+disable-model-invocation: true
+argument-hint: "你想学习什么？"
+---
+```
 
 ## Translation style
 

--- a/skills/in-progress/loop-me/SKILL.md
+++ b/skills/in-progress/loop-me/SKILL.md
@@ -2,7 +2,7 @@
 name: loop-me
 description: 在这个工作区中，就我想构建的工作流规格访谈我。
 disable-model-invocation: true
-argument-hint: "A workflow to design, or nothing to go find one"
+argument-hint: "一个待设计的工作流；也可以留空，让我去找一个"
 ---
 
 运行一个 stateful `/grilling` session，唯一输出是 **workflow** specs。使用 grilling discipline：持续追问、一次一个问题、每个问题都附推荐答案。围绕下面的 vocabulary 和 goal 来访谈。随着 grilling 解决问题，创建、编辑、删除 specs。

--- a/skills/productivity/handoff/SKILL.md
+++ b/skills/productivity/handoff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: handoff
 description: 把当前对话压缩成交接文档，让另一个代理接手。
-argument-hint: "What will the next session be used for?"
+argument-hint: "下一个会话将用于什么？"
 disable-model-invocation: true
 ---
 

--- a/skills/productivity/teach/SKILL.md
+++ b/skills/productivity/teach/SKILL.md
@@ -2,7 +2,7 @@
 name: teach
 description: 在这个工作区中教用户一个新技能或概念。
 disable-model-invocation: true
-argument-hint: "What would you like to learn about?"
+argument-hint: "你想学习什么？"
 ---
 
 用户要求你教他们某件事。这是一个 stateful request：他们打算在多个 sessions 中学习这个 topic。


### PR DESCRIPTION
## Summary

- define a general translation rule for natural-language frontmatter values
- explicitly cover `description` and `argument-hint` while preserving structural and behavior-critical values
- translate all existing `argument-hint` values into Simplified Chinese

## Why

The localization policy previously mentioned only `description`, leaving other user-facing frontmatter such as `argument-hint` untranslated.

## Impact

Skill argument prompts are now presented consistently in Simplified Chinese, and future natural-language frontmatter fields have a clear localization rule.

## Validation

- `node scripts/check-translation.mjs`
- `git diff --check`
- verified no English `argument-hint` values remain in tracked skills