### PR TITLE
docs: 新增翻译术语表与社区翻译贡献机制（术语表 / CONTRIBUTING / 同步工作清单 / 覆盖审计）

### DIFF
--- a/.skills/translate-skill/SKILL.md
+++ b/.skills/translate-skill/SKILL.md
@@ -112,6 +112,8 @@ consistent with existing repo tone
 
 Keep common engineering terms in English when the English term is standard among developers or when translating it would reduce clarity.
 
+The per-term ruling (keep English vs translate) for every recurring term is registered in the top-level [`TRANSLATE_GLOSSARY.md`](../../TRANSLATE_GLOSSARY.md). Before translating, consult it and render each term exactly as it rules, so the same term is never written differently across files. If you meet a recurring term the glossary does not yet cover, keep the keep-English default and flag it so it can be registered.
+
 ## Workflow for a single file
 
 When translating one file:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,4 @@ Skills 按 bucket folder 组织在 `skills/` 下：
 
 ## 翻译刷新
 
-从 `mattpocock/skills` 刷新上游内容时，改文件前先使用 `.skills/translate-skill/SKILL.md`。本仓库采用 skill-guided content localization，不做 Git fork-sync：保留简体中文本地化身份，安装命令保持指向 `vinvcn/mattpocock-skills-zh-CN`，不要导入上游 repository-management state。
+从 `mattpocock/skills` 刷新上游内容时，改文件前先使用 `.skills/translate-skill/SKILL.md`。本仓库采用 skill-guided content localization，不做 Git fork-sync：保留简体中文本地化身份，安装命令保持指向 `vinvcn/mattpocock-skills-zh-CN`，不要导入上游 repository-management state。recurring 术语的译法（保留英文 vs 翻译）统一对照顶层 `TRANSLATE_GLOSSARY.md`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,7 @@ Skills 按 bucket folder 组织在 `skills/` 下：
 每个 `SKILL.md` 要么是 user-invoked（frontmatter 中设置 `disable-model-invocation: true`，并在 `agents/openai.yaml` 中设置 `policy.allow_implicit_invocation: false`，只能由人类显式调用），要么是 model-invoked（模型和用户都可以调用）。完整定义、description 约定，以及为什么 user-invoked skill 可以调用 model-invoked skills 但不能调用另一个 user-invoked skill，见 [docs/invocation.md](./docs/invocation.md)。
 
 本仓库也是一个单 plugin 的 Claude Code marketplace：`.claude-plugin/marketplace.json` 列出唯一的 `mattpocock-skills` plugin。修改 `.claude-plugin/plugin.json` 或 marketplace manifest 后，运行 `claude plugin validate . --strict`。Plugin 的公开 skill 集合继续遵循本仓库 bucket 规则。
+
+## 翻译刷新
+
+从 `mattpocock/skills` 刷新上游内容时，改文件前先使用 `.skills/translate-skill/SKILL.md`。本仓库采用 skill-guided content localization，不做 Git fork-sync：保留简体中文本地化身份，安装命令保持指向 `vinvcn/mattpocock-skills-zh-CN`，不要导入上游 repository-management state。recurring 术语的译法（保留英文 vs 翻译）统一对照顶层 `TRANSLATE_GLOSSARY.md`。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# 参与贡献（Contributing）
+
+这个仓库是 [`mattpocock/skills`](https://github.com/mattpocock/skills) 的**简体中文本地化版**。我们按“内容刷新”的方式同步上游：只翻译自然语言说明，保留目录名、skill name、命令、代码块、路径和各类 identifiers。
+
+欢迎你帮忙提升翻译质量。**你的贡献不是一次性的**——本仓库会持续从上游同步，而你沉淀下来的术语裁决、翻译约定和既有译文，会在每一次未来同步中被复用。
+
+## 你可以怎么帮忙
+
+有三种方式，按“对未来同步的杠杆”从高到低：
+
+### 1. 扩充术语表（最高杠杆）
+
+术语比句子稳定得多：上游内容会变，术语基本不变。每在 [`TRANSLATE_GLOSSARY.md`](./TRANSLATE_GLOSSARY.md) 里多登记一条裁决，未来每次同步就少一个临时决定、少一处不一致。翻译工具（`.skills/translate-skill/SKILL.md`）在每次刷新时都会查这份术语表。
+
+这也是最好的 **good-first-issue**：认领“给某个高频词登记裁决”即可。
+
+### 2. 翻译同步增量（delta）
+
+每次上游刷新后，运行工作清单脚本，只翻译**相对上次同步点有变化**的内容；稳定内容的既有译文自动保留：
+
+```bash
+git fetch upstream
+node scripts/sync-worklist.mjs <上次同步的上游SHA> upstream/main
+```
+
+清单会按 bucket 分组列出“新增 / 变更 / 移除”的 `.md` 文件，并标注是“需首次翻译”还是“需更新既有译文”。认领你感兴趣的条目即可。
+
+### 3. 审计与修复翻漏
+
+运行覆盖审计，定位正文里残留的英文：
+
+```bash
+node scripts/audit-coverage.mjs
+```
+
+它会报告高频英文术语（术语表扩表候选）和 function-word 残留（意味着“整句英文没翻译”），并按文件排出密度。挑一个密度高的文件，把残留英文翻成中文、或把术语登记进术语表。
+
+## 翻译规则
+
+翻译前先读 [`.skills/translate-skill/SKILL.md`](./.skills/translate-skill/SKILL.md)。核心原则：
+
+- **翻译**自然语言 prose；**原样保留**目录名、skill name、slash command、CLI 命令、代码块、inline code、路径、package/tool/API identifiers、frontmatter key、URL 和行为关键 labels。
+- 安装命令里的 repo 路径统一保持 `vinvcn/mattpocock-skills-zh-CN`。
+- recurring 术语的译法**对照 [`TRANSLATE_GLOSSARY.md`](./TRANSLATE_GLOSSARY.md)**；默认保留开发者通用的工程 / 领域术语为英文。
+- 拿不准是否行为关键时，**保留并标记**（fail-closed），不要擅自改写。
+
+## 如何认领任务
+
+1. 查看带 **`translation`** label 的 [issues](https://github.com/vinvcn/mattpocock-skills-zh-CN/issues?q=label%3Atranslation)。
+2. 在想认领的 issue 下评论（例如“我来做这个”），避免重复劳动。
+3. 对于同步增量，也可以在 `sync-worklist` 输出的条目 `[ ]` 里填上你的用户名。
+
+## 如何给术语表加一条词条
+
+在 [`TRANSLATE_GLOSSARY.md`](./TRANSLATE_GLOSSARY.md) 对应的表里加一行，五列：
+
+| 英文术语 | 统一译法 / 裁决 | 来源文档 | 避免（_Avoid_） | 说明 |
+|---|---|---|---|---|
+| `example term` | 保留英文 或 指定中文 | `docs/.../xxx.md` | 不该用的译法 | 一句话说明 |
+
+- 保留英文的词，`统一译法 / 裁决` 写 `保留英文`，并在 `避免` 里列出别去翻成的中文。
+- 若某个词在 `description:` 里有刻意的中文写法而正文保留英文，在 `说明` 里注明。
+
+## 提交前自检
+
+```bash
+node scripts/check-translation.mjs   # 结构 / frontmatter / install path / license invariants
+node scripts/audit-coverage.mjs      # 翻译覆盖画像（advisory）
+```
+
+## 为什么这对未来同步有益
+
+- **术语表增长** → 每次 `translate-skill` 刷新都从更完整的裁决出发，更快、更一致。
+- **delta 工作清单** → 贡献者不重复翻译稳定内容，既有译文跨同步保留。
+- **周期性审计** → 翻漏被自动发现并修复，质量只升不降。
+
+感谢你的参与 🙏

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@
 
 本仓库的最近一次同步翻译由 Claude（Anthropic）执行，并由仓库维护者通过 PR 纳入 `main`。翻译策略是 **skill-guided content localization**：把上游 `mattpocock/skills` 当作英文内容来源，只翻译自然语言说明，保留目录名、skill name、frontmatter key、命令、代码块、路径、URL、package/tool/API identifiers 和行为关键 labels。用户可见的安装路径统一保持为 `vinvcn/mattpocock-skills-zh-CN`。
 
+## 参与改进翻译（Contributing）
+
+欢迎帮忙提升翻译质量。本仓库会持续从上游同步，你沉淀的**术语裁决、翻译约定和既有译文会在每次未来同步中复用**——贡献不是一次性的。三种参与方式：
+
+- **扩充术语表**：在 [`TRANSLATE_GLOSSARY.md`](./TRANSLATE_GLOSSARY.md) 为 recurring 术语登记译法裁决（最高杠杆，也是最好的 good-first-issue）。
+- **翻译同步增量**：用 `node scripts/sync-worklist.mjs <上次同步SHA> upstream/main` 生成只含变更内容的工作清单，认领条目翻译。
+- **审计翻漏**：用 `node scripts/audit-coverage.mjs` 定位正文残留的英文句子与未登记术语，并修复。
+
+完整指南见 [`CONTRIBUTING.md`](./CONTRIBUTING.md)；可认领的任务见带 `translation` label 的 issues。
+
 ## 30 秒安装
 
 ```bash

--- a/TRANSLATE_GLOSSARY.md
+++ b/TRANSLATE_GLOSSARY.md
@@ -1,0 +1,82 @@
+# 翻译术语表（Translation Glossary）
+
+本表是本仓库 recurring 术语**译法**的唯一事实来源：每个词要么统一译成指定中文，要么「保留英文」。翻译或刷新上游内容（见 [`.skills/translate-skill/SKILL.md`](./.skills/translate-skill/SKILL.md)）时对照本表，避免同一术语在不同文件里中英混用。
+
+**默认规则**：开发者通用的工程 / 领域术语保留英文。本表把「该译的」和「该保留的」都显式列出，以消除不一致。
+
+**与 `CONTEXT.md` 的关系**：`CONTEXT.md` 承载 issue / triage 领域的 ubiquitous language **定义**；本表承载全仓库术语的**译法裁决**。两者互补，不重叠——要理解一个 domain term 的含义，查 `CONTEXT.md`；要决定它怎么写（中 or 英），查本表。
+
+**关于交叉链接**：`来源文档` 列指向每个术语的 canonical doc，为将来的 skill ↔ 术语表交叉链接留好落点；当前不改动任何 skill 文件（内联链接已推迟）。
+
+> 约定：`统一译法 / 裁决` 列写「保留英文」表示正文保持英文原词；若某词在 `description:` 里有刻意的中文写法，会在 `说明` 列注明（正文与 `description:` 可分别保持一致）。
+
+## 核心领域与流程术语
+
+| 英文术语 | 统一译法 / 裁决 | 来源文档 | 避免（_Avoid_） | 说明 |
+|---|---|---|---|---|
+| branch | 保留英文 | `docs/productivity/grilling.md` | 分支 | 指 design tree 的分支；git 分支语境同样保留 `branch` |
+| bucket | 保留英文 | `CLAUDE.md` | 桶、分类目录 | `skills/` 下的组织目录（engineering / productivity / misc 等） |
+| decision | 保留英文 | `docs/productivity/grilling.md` | 决策 | design tree 中挂在其它 decision 下的决定；正文保留英文 |
+| deep module | 保留英文 | `docs/engineering/codebase-design.md` | 深模块 | 小接口、承载复杂度的模块；`description:` 曾用「深模块」，正文保留英文 |
+| deepening | 保留英文 | `docs/engineering/improve-codebase-architecture.md` | 深化 | 把 shallow module 变深的过程；`description:` 曾用「深化」 |
+| design tree | 保留英文 | `docs/productivity/grilling.md` | 决策树、设计树 | grilling 对主题的建模：decision 下挂 decision |
+| domain model | 保留英文 | `docs/engineering/domain-modeling.md` | 领域模型 | 项目的领域模型；`description:` 曾用「领域模型」，正文保留英文 |
+| feedback loop | 保留英文 | `docs/engineering/diagnosing-bugs.md` | 反馈循环 | 对生成代码真实运行情况的反馈（types / tests / browser） |
+| frontier | 保留英文 | `docs/productivity/grilling.md` | 前沿 | 前提已敲定、当前可问的 decision 集合 |
+| grilling / grill | 保留英文 | `docs/productivity/grilling.md` | 追问、访谈、拷问 | 追问式访谈循环；`description:` 用「追问式访谈」，正文保留 `grilling`；作动词亦保留（如「grill 它」） |
+| handoff | 保留英文 | `docs/productivity/handoff.md` | 交接 | 把对话压缩成交接文档；`description:` 曾用「交接」，正文保留 `handoff` |
+| harness | 保留英文 | `docs/productivity/handoff.md` | 框架、宿主 | 运行 agent 的宿主环境（Claude Code / Codex 等） |
+| issue | 保留英文 | `CONTEXT.md` | 工单、问题 | issue tracker 中被跟踪的工作单元；作 domain term 时首字母大写 `Issue` |
+| issue tracker | 保留英文 | `CONTEXT.md` | backlog、工单系统 | 托管 repo issues 的工具（GitHub Issues / Linear / 本地文件） |
+| marketplace | 保留英文 | `CLAUDE.md` | 市场 | Claude Code plugin marketplace |
+| materialization | 保留英文 | `README.md` | 物化 | 「materialization cascade」示例中的术语，保持上游用法 |
+| model-invoked / user-invoked | 保留英文 | `docs/invocation.md` | 模型调用、用户调用 | 按「谁能调用」区分的两类 skill |
+| plugin | 保留英文 | `CLAUDE.md` | 插件 | Claude Code plugin |
+| prototype | 保留英文 | `docs/engineering/prototype.md` | 原型 | 回答一个设计问题的一次性代码 |
+| questionnaire | 保留英文 | `docs/productivity/to-questionnaire.md` | 问卷 | 交给掌握你所缺信息的人的 Markdown document |
+| red-green-refactor | 保留英文 | `docs/engineering/tdd.md` | 红绿重构 | TDD 循环；颜色机制可说「变红 / 变绿」 |
+| seam | 保留英文 | `docs/engineering/codebase-design.md` | 接缝 | 不编辑当前位置即可改变行为的地方（Michael Feathers） |
+| session | 保留英文 | `docs/productivity/grilling.md` | 会话 | 一次 agent 会话 |
+| shared language / ubiquitous language | 保留英文 | `docs/engineering/domain-modeling.md` | 共享语言、通用语言 | 帮 agent 解码项目术语的共享词汇 |
+| skill | 保留英文 | `README.md` | 技能 | 本仓库的核心单元；`description:` 偶用「技能」，正文保留 `skill` |
+| spec | 保留英文 | `docs/engineering/to-spec.md` | 规格、说明书 | `to-spec` 产出的规格 |
+| sub-agent | 保留英文 | `docs/productivity/grilling.md` | 子代理、子智能体 | 被派去查明 fact 的 agent；统一连字符写法 `sub-agent` |
+| test | 保留英文 | `docs/engineering/tdd.md` | 测试 | 指代码测试这一概念时保留 `test` / `tests`；「跑测试」这类口语表达可用中文 |
+| ticket | 保留英文 | `docs/engineering/to-tickets.md` | 工单、票据 | `to-tickets` 产出的工作单元；仅在指外部系统或 Decision ticket 时使用 |
+| tracer bullet | 保留英文 | `docs/engineering/to-tickets.md` | 曳光弹 | 穿过 change 每一层的窄而完整的路径 |
+| triage | 保留英文 | `docs/engineering/triage.md` | 分诊、分检 | 通过 triage roles 推进 issues |
+| vertical slice | 保留英文 | `docs/engineering/tdd.md` | 垂直切片 | 一个 seam、一个 test、一个最小实现 |
+
+## 缩写与专名（一律保留英文）
+
+这些是缩写、产品名、工具名、文件名或人名，保留英文，不要翻译。与 `scripts/audit-english.mjs` 的 allowlist 保持一致。
+
+| 英文术语 | 统一译法 / 裁决 | 来源文档 | 避免（_Avoid_） | 说明 |
+|---|---|---|---|---|
+| ADR | 保留英文 | `docs/engineering/grill-with-docs.md` | 架构决策记录 | Architecture Decision Record，落盘到 `docs/adr/` |
+| API | 保留英文 | — | 应用程序接口 | 工具 / API 标识 |
+| CI / CD | 保留英文 | — | 持续集成 / 持续部署 | |
+| CLI | 保留英文 | — | 命令行界面 | |
+| Claude | 保留英文 | — | — | 产品名 |
+| Codex | 保留英文 | — | — | 产品名 |
+| DDD | 保留英文 | `docs/engineering/domain-modeling.md` | 领域驱动设计 | Domain-Driven Design |
+| GitHub | 保留英文 | — | — | 产品名 |
+| Husky | 保留英文 | — | — | 工具名 |
+| LICENSE | 保留英文 | — | 许可证 | 文件名 |
+| lint-staged | 保留英文 | — | — | 工具名 |
+| Matt Pocock | 保留英文 | — | — | 人名（上游作者，保留署名） |
+| MIT | 保留英文 | `LICENSE` | — | License 名 |
+| mock | 保留英文 | `docs/engineering/tdd.md` | 模拟 | 测试中的 mock；作概念保留英文 |
+| Obsidian | 保留英文 | — | — | 产品名 |
+| Prettier | 保留英文 | — | — | 工具名 |
+| PRD | 保留英文 | — | 产品需求文档 | Product Requirements Document |
+| README | 保留英文 | — | 自述文件 | 文件名 |
+| refactor | 保留英文 | `docs/engineering/tdd.md` | 重构 | 作概念保留 `refactor` / `refactoring`；「重构」在口语表达中可用 |
+| SKILL | 保留英文 | — | — | 文件名 / 标识（`SKILL.md`） |
+| TDD | 保留英文 | `docs/engineering/tdd.md` | 测试驱动开发 | Test-Driven Development |
+
+## 维护
+
+- 新增一个 recurring 术语、或发现同一术语出现多种译法时，先在本表登记裁决，再在翻译中使用。
+- 本表是参考文档（advisory），不接入 `scripts/check-translation.mjs` / `audit-english.mjs` 做硬性校验；`audit-english.mjs` 仍只作为人工复核队列。
+- 修正现有文件中已存在的不一致（按本表逐处对齐）是独立的后续一步，不包含在术语表本身内。

--- a/research/english-coverage.md
+++ b/research/english-coverage.md
@@ -1,0 +1,68 @@
+# English 覆盖分析报告
+
+> 生成日期：2026-08-12。目的：查清仓库正文（translatable prose）中残留的英文术语与英文句子，评估翻译覆盖情况，为 `TRANSLATE_GLOSSARY.md` 扩表提供依据。
+
+## 范围与方法
+
+- 范围：98 个 git-tracked `.md` 文件（排除 `LICENSE.zh-CN.md`、`.claude/worktrees/`、未跟踪的 `.agents/skills/` 与 `research/`）。
+- 按 `.skills/translate-skill/SKILL.md` 的 coverage 规则剥除不可翻译区：frontmatter、fenced code blocks、inline code、图片、链接 URL（保留链接文字）、裸 URL、文件路径、slash command、skill names。
+- 对剩余正文提取英文 token，按词频排序；并单独统计 **function words**（the/and/when/what…）——它们不属于领域术语，出现即意味着**未翻译的英文句子**。
+
+## 结论（TL;DR）
+
+仓库**只部分本地化**，且存在两种不同性质的英文残留：
+
+1. **守住“保留英文”策略的领域术语**（主体）：剥离后正文仍有约 **15,126 个英文内容 token**，共 **2,436 个不同词**。当前 53 词术语表只覆盖了其中最高频的一小部分（约 30 个词条命中 top 词频），词汇量远超术语表。
+2. **未翻译的英文句子/片段**（翻漏）：正文残留 **848 个 function words**（本地化内容，不含刻意用英文的 translate-skill），集中在约 15 个文件里。这是“译文里夹着整句英文”的翻漏，不是术语问题。
+
+## 未翻译英文句子最集中的文件（function-word 密度）
+
+| func# | func% | 文件 |
+|---|---|---|
+| 108 | 20% | `.skills/translate-skill/SKILL.md`（刻意英文） |
+| 47 | 16% | `skills/in-progress/writing-shape/SKILL.md` |
+| 40 | 10% | `docs/engineering/codebase-design.md` |
+| 39 | 12% | `skills/engineering/code-review/SKILL.md` |
+| 31 | 10% | `skills/engineering/prototype/UI.md` |
+| 29 | 20% | `skills/engineering/domain-modeling/ADR-FORMAT.md` |
+| 29 | 11% | `skills/engineering/prototype/LOGIC.md` |
+| 24 | 5% | `skills/engineering/wayfinder/SKILL.md` |
+| 23 | 4% | `README.md` |
+| 23 | 14% | `skills/engineering/ask-matt/PHASE-BOUNDARIES.md` |
+| 21 | 8% | `docs/engineering/setup-matt-pocock-skills.md` |
+| 20 | 6% | `docs/engineering/diagnosing-bugs.md` |
+| 19 | 11% | `skills/engineering/triage/OUT-OF-SCOPE.md` |
+| 17 | 15% | `skills/engineering/domain-modeling/SKILL.md` |
+| 14 | 8% | `docs/productivity/grilling.md` |
+
+> function% = 该文件剥离后英文 token 中 function words 占比。占比越高，说明越像“整段英文没翻”，而不是“中译里夹术语”。
+
+## 高频内容词（freq≥10，共 307 个）——术语表扩表候选
+
+按词频降序，前 60 个为代表：
+
+```
+agent(299) session(202) issue(201) ticket(194) spec(163) skills(151) repo(145)
+tracker(139) context(129) tickets(120) interface(115) map(115) seam(108) module(108)
+test(103) code(80) bug(79) implementation(79) decision(76) tests(72) issues(71)
+codebase(71) loop(71) model(66) state(64) branch(58) github(57) phase(55)
+decisions(54) domain(53) glossary(51) adr(50) markdown(49) label(49) seams(49)
+file(48) frontier(48) reference(47) diff(47) review(45) source(45) commit(45)
+user-invoked(44) flow(44) feature(43) build(42) working(42) claude(41) deep(41)
+files(40) main(39) scope(38) pointer(38) questions(37) primary(37) beat(37)
+grounded(37) package(36) adrs(36) brief(36)
+```
+
+完整清单可用 `node scripts/audit-coverage.mjs --min-freq 1` 复现（该脚本即本报告的分析工具）。
+
+## 与当前 53 词术语表的差距
+
+- 当前 53 词表覆盖了最高频的约 30 个核心词（skill/agent/session/issue/ticket/spec/tracker/context/interface/seam/module/test/branch/domain/adr/frontier/grilling/triage…）。
+- 但高频候选有 **307 个（freq≥10）**、全量有 **2,436 个**，且混有大量工具/专名（markdown/diff/review/commit/github/gitlab/html/config…）与普通英文词（working/feature/build/file…）。
+- 结论：**“一个词一条裁决”的术语表思路，无法也无必要覆盖到 2,436 的量级。** 术语表应继续做“决策型 + 易混型”的精选集合；真正的两件事是——(1) 收紧/明确 keep-English 边界，避免整句英文；(2) 对上述 ~15 个文件做一次翻译补齐。
+
+## 建议
+
+1. **术语表保持精选**，但补上本报告 top 高频里遗漏的、确有“中英摇摆”的词（如 `phase`、`state`、`build`、`release`、`scope`、`review`、`commit`、`merge`、`loop`、`shallow/deep`、`adapter`、`flow`、`map`、`root`、`boundary`、`entry`、`fog`、`glass`…）。
+2. **另起“翻译补齐”工作**：对 function-word 密度高的 ~15 个文件，把残留英文句子翻成中文（这是翻漏，不是术语问题）。
+3. 若想进一步压缩英文量，可收紧 keep-English 策略（例如只在“首次出现标英文、后文用中文”时保留，或限定保留词表）。

--- a/scripts/audit-coverage.mjs
+++ b/scripts/audit-coverage.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// audit-coverage.mjs — 翻译覆盖审计（advisory，只作为人工复核队列，不做硬性失败）
+//
+// 目的：在剥离“不可翻译区”之后，量化正文里残留的英文，帮助定位：
+//   ① 高频英文术语（术语表 TRANSLATE_GLOSSARY.md 的扩表候选）
+//   ② function words（the/and/when/…）——它们不属于领域术语，出现即意味着“未翻译的英文句子”
+//
+// 剥离规则遵循 .skills/translate-skill/SKILL.md 的 coverage：frontmatter、fenced code、
+// inline code、图片、链接 URL（保留链接文字）、裸 URL、文件路径、slash command、skill names。
+//
+// 用法：
+//   node scripts/audit-coverage.mjs [--top 25] [--min-freq 10]
+//
+// 与 scripts/audit-english.mjs 的关系：audit-english 逐行找“疑似整句英文”；本脚本从“术语 + 词频”
+// 角度给出覆盖画像。两者都是 review flag，不阻断流程。
+
+import fs from "node:fs";
+import { execSync } from "node:child_process";
+
+// ---- parse args ----
+const argv = process.argv.slice(2);
+function argOf(flag, dflt) {
+  const i = argv.indexOf(flag);
+  return i >= 0 && argv[i + 1] ? Number(argv[i + 1]) : dflt;
+}
+const TOP = argOf("--top", 25);
+const MIN_FREQ = argOf("--min-freq", 10);
+
+// ---- in-scope tracked .md files ----
+const files = execSync("git ls-files '*.md'", { encoding: "utf8" })
+  .trim().split("\n")
+  .filter((f) => f && fs.existsSync(f))
+  .filter((f) => !f.startsWith(".claude/worktrees/"))
+  .filter((f) => f.endsWith(".md") && f !== "LICENSE.zh-CN.md");
+
+// skill names, to be stripped (they are preserved identifiers, not translatable prose)
+const skillNames = execSync(
+  "git ls-files 'skills/*/SKILL.md' '.skills/*/SKILL.md' '.agents/skills/*/SKILL.md'",
+  { encoding: "utf8" }
+).trim().split("\n").filter(Boolean).map((p) => p.split("/").slice(-2)[0]);
+
+// pure grammatical function words -> their presence marks untranslated English prose
+const FUNC = new Set(["the","and","of","to","in","for","with","on","at","by","from","this","that","these","those","it","its","is","are","was","were","be","been","being","have","has","had","do","does","did","will","would","should","could","can","may","might","must","not","no","so","but","or","nor","if","when","where","which","who","whom","whose","what","how","why","then","than","there","here","as","all","any","both","each","few","more","most","other","some","such","only","own","same","into","onto","upon","within","without","about","between","under","over","after","before","during"]);
+
+// ---- stripping helpers (per translate-skill "preserve exactly") ----
+const stripFrontmatter = (t) => t.replace(/^---\n[\s\S]*?\n---\n/, "");
+const stripCodeFences = (t) => t.replace(/```[\s\S]*?```/g, " ");
+const stripInlineCode = (t) => t.replace(/`[^`\n]*`/g, " ");
+const stripImages = (t) => t.replace(/!\[[^\]]*\]\([^)]*\)/g, " ");
+const stripLinkUrls = (t) => t.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1"); // keep link text
+const stripBareUrls = (t) => t.replace(/https?:\/\/\S+/g, " ");
+const stripSlashCmds = (t) => t.replace(/\/[a-z][a-z0-9-]*/gi, " ");
+const stripFilePaths = (t) =>
+  t
+    .replace(/[\w.@/-]+\.(md|json|ya?ml|js|mjs|cjs|ts|tsx|sh|html|png|jpg|jpeg|svg)\b/gi, " ")
+    .replace(/\b[\w.-]+\/[\w./-]+\b/g, " ");
+
+const isIntentionallyEnglish = (f) => f.startsWith(".skills/translate-skill");
+
+const tokenFreq = new Map();
+const tokenFiles = new Map();
+const funcFreq = new Map();
+const perFile = new Map(); // file -> {func, content, total}
+
+for (const file of files) {
+  let text = fs.readFileSync(file, "utf8");
+  text = stripFrontmatter(text);
+  text = stripCodeFences(text);
+  text = stripInlineCode(text);
+  text = stripImages(text);
+  text = stripLinkUrls(text);
+  text = stripBareUrls(text);
+  text = stripFilePaths(text);
+  text = stripSlashCmds(text);
+  for (const n of skillNames) {
+    text = text.replace(new RegExp("\\b" + n.replace(/[-/]/g, "\\$&") + "\\b", "g"), " ");
+  }
+
+  const tokens = text.match(/[A-Za-z][A-Za-z'-]*[A-Za-z]|[A-Za-z]{2}/g) || [];
+  let func = 0, content = 0;
+  for (const t0 of tokens) {
+    const t = t0.toLowerCase();
+    if (t.length < 3) continue;
+    if (FUNC.has(t)) {
+      func++;
+      funcFreq.set(t, (funcFreq.get(t) || 0) + 1);
+    } else {
+      content++;
+      tokenFreq.set(t, (tokenFreq.get(t) || 0) + 1);
+      if (!tokenFiles.has(t)) tokenFiles.set(t, new Set());
+      tokenFiles.get(t).add(file);
+    }
+  }
+  perFile.set(file, { func, content, total: func + content });
+}
+
+const funcLocalized = [...perFile.entries()]
+  .filter(([f]) => !isIntentionallyEnglish(f))
+  .reduce((s, [, { func }]) => s + func, 0);
+
+console.log("# 翻译覆盖审计（advisory）");
+console.log(`\n分析文件数: ${files.length}`);
+console.log(`正文英文内容 token 总数: ${[...perFile.values()].reduce((s, x) => s + x.content, 0)}`);
+console.log(`未翻译英文句子指标（function words，本地化内容，不含刻意英文的 translate-skill）: ${funcLocalized}`);
+
+console.log(`\n## 高频英文术语（freq ≥ ${MIN_FREQ}）— 术语表扩表候选`);
+[...tokenFreq.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .filter(([, c]) => c >= MIN_FREQ)
+  .slice(0, 120)
+  .forEach(([t, c]) => console.log(`  ${String(c).padStart(5)}  ${t.padEnd(28)} [${tokenFiles.get(t).size} 文件]`));
+
+console.log(`\n## function-word 残留（freq ≥ 2）— 未翻译英文句子指标`);
+[...funcFreq.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .filter(([, c]) => c >= 2)
+  .forEach(([t, c]) => console.log(`  ${String(c).padStart(5)}  ${t}`));
+
+console.log(`\n## 未翻译英文最集中的文件（top ${TOP}，按 function-word 数）`);
+console.log("func# | func% | 文件");
+[...perFile.entries()]
+  .sort((a, b) => b[1].func - a[1].func)
+  .slice(0, TOP)
+  .forEach(([f, { func, total }]) => {
+    const tag = isIntentionallyEnglish(f) ? "  [刻意英文]" : "";
+    const pct = total ? Math.round((func / total) * 100) : 0;
+    console.log(`${String(func).padStart(5)} | ${String(pct).padStart(3)}% | ${f}${tag}`);
+  });
+
+console.log("\n说明：本脚本仅输出 review 信息，始终以退出码 0 结束，不阻断 CI。");

--- a/scripts/sync-worklist.mjs
+++ b/scripts/sync-worklist.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// sync-worklist.mjs — 生成“上游同步翻译工作清单”
+//
+// 目的：每次从上游 mattpocock/skills 做内容刷新（content refresh）时，产出一份可认领的翻译
+// 工作清单——只列出相对上次同步点“新增/变更/移除”的 in-scope .md 内容文件，让贡献者只翻译
+// 增量（delta），稳定内容的既有译文自动保留，从而让社区贡献在未来的同步中持续复用。
+//
+// 用法：
+//   node scripts/sync-worklist.mjs <last-synced-upstream-sha> [upstream-ref]
+//     <last-synced-upstream-sha>  上次同步对应的上游 short/full SHA（见 README 同步记录）
+//     [upstream-ref]              默认 upstream/main；先 `git fetch upstream` 确保已抓取
+//
+// 输出：Markdown 工作清单（stdout），按 bucket 分组、每项带认领 checkbox，并标注该文件在本仓库
+// 是否已有对应译文（“需首次翻译” vs “需更新/复核既有译文”）。
+
+import fs from "node:fs";
+import { execSync as run } from "node:child_process";
+
+const [baseSha, upstreamRef = "upstream/main"] = process.argv.slice(2);
+
+function die(msg) {
+  console.error(`错误：${msg}`);
+  console.error("\n用法：node scripts/sync-worklist.mjs <last-synced-upstream-sha> [upstream-ref]");
+  console.error("  例如：node scripts/sync-worklist.mjs 733d312 upstream/main");
+  console.error("  上次同步的上游 SHA 见 README 的同步记录（sync log）。");
+  process.exit(1);
+}
+function revExists(rev) {
+  try { run(`git rev-parse --verify ${rev}^{commit}`, { encoding: "utf8", stdio: "pipe" }); return true; }
+  catch { return false; }
+}
+
+if (!baseSha) die("缺少 <last-synced-upstream-sha> 参数。");
+if (!revExists(baseSha)) die(`找不到 commit ${baseSha}。请确认它是有效的上游 SHA。`);
+if (!revExists(upstreamRef)) die(`找不到 ref ${upstreamRef}。请先运行：git fetch upstream`);
+
+// 上游 base..upstreamRef 之间变更的 .md 文件
+const raw = run(`git diff --name-status ${baseSha}..${upstreamRef} -- '*.md'`, { encoding: "utf8" });
+const entries = raw.trim().split("\n").filter(Boolean).map((line) => {
+  const [status, ...rest] = line.split("\t");
+  // 处理 rename：R100\told\tnew -> 取新路径
+  const path = rest.length > 1 ? rest[1] : rest[0];
+  return { status: status[0], path };
+});
+
+// in-scope：排除 LICENSE（不翻译）、worktree
+const inScope = entries.filter(
+  (e) => e.path.endsWith(".md") && !/LICENSE/i.test(e.path) && !e.path.startsWith(".claude/worktrees/")
+);
+
+if (!inScope.length) {
+  console.log(`# 同步翻译工作清单\n\n相对 ${baseSha}..${upstreamRef}，没有 in-scope 的 .md 内容变更。无需翻译增量。`);
+  process.exit(0);
+}
+
+// 本地是否已有对应译文（同路径）
+const hasLocal = (p) => fs.existsSync(p);
+const statusLabel = { A: "新增", M: "变更", D: "移除", R: "重命名" };
+
+// 分组：按 bucket / 顶层目录
+function groupKey(p) {
+  const parts = p.split("/");
+  if (parts[0] === "skills" && parts.length >= 2) return `skills/${parts[1]}`;
+  if (parts[0] === "docs" && parts.length >= 2) return `docs/${parts[1]}`;
+  return parts[0] || "root";
+}
+const groups = new Map();
+for (const e of inScope) {
+  const k = groupKey(e.path);
+  if (!groups.has(k)) groups.set(k, []);
+  groups.get(k).push(e);
+}
+const orderedKeys = [...groups.keys()].sort();
+
+console.log("# 同步翻译工作清单");
+console.log("");
+console.log(`上游对比范围：\`${baseSha}..${upstreamRef}\``);
+console.log(`in-scope 变更文件：${inScope.length} 个（新增/变更/移除/重命名）。`);
+console.log("");
+console.log("> 认领方式：在自己认领的条目 `[ ]` 里填上自己的 GitHub 用户名，例如 `[x] @yourname`。");
+console.log("> “需首次翻译”= 本仓库尚无对应译文；“需更新/复核”= 已有译文，需对照上游变更刷新。");
+console.log("");
+
+for (const k of orderedKeys) {
+  console.log(`## ${k}`);
+  console.log("");
+  for (const e of groups.get(k).sort((a, b) => a.path.localeCompare(b.path))) {
+    const s = statusLabel[e.status] || e.status;
+    if (e.status === "D") {
+      console.log(`- [ ] ~~\`${e.path}\`~~ —— 上游已移除（${s}）：考虑同步移除本地译文或标记 stale`);
+      continue;
+    }
+    const local = hasLocal(e.path);
+    const action = local ? "需更新/复核既有译文" : "需首次翻译";
+    console.log(`- [ ] \`${e.path}\` —— 上游${s} · ${action}`);
+  }
+  console.log("");
+}
+
+console.log("## 完成每个条目后");
+console.log("");
+console.log("1. 翻译时遵循 `.skills/translate-skill/SKILL.md` 的规则。");
+console.log("2. 遇到新的 recurring 术语，顺手在 `TRANSLATE_GLOSSARY.md` 登记裁决。");
+console.log("3. 完成后运行 `node scripts/check-translation.mjs` 与 `node scripts/audit-coverage.mjs` 自检。");


### PR DESCRIPTION
## 背景

本仓库是 `mattpocock/skills` 的简体中文本地化版。此前缺少两样东西：

1. 一份把「保留英文 vs 翻译」策略真正落地的术语表，导致同一术语在不同文件里中英混用；
2. 一套让社区贡献能在**未来每次上游同步中持续复用**的机制。

## 本 PR 做了什么

### 一、翻译术语表（`d2f350d`）
- 新增顶层 `TRANSLATE_GLOSSARY.md`：53 个 recurring 术语的译法裁决（32 个核心领域/流程术语 + 21 个缩写与专名，后者一律保留英文并与 `scripts/audit-english.mjs` 的 allowlist 对齐）。五列格式：英文术语 / 统一译法·裁决 / 来源文档 / 避免(_Avoid_) / 说明。
- `.skills/translate-skill/SKILL.md`：在 Translation style 加入术语表指针，翻译时对照执行。
- `CLAUDE.md` / `AGENTS.md`：在「翻译刷新」加入术语表指针，并为 `CLAUDE.md` 补齐该节，使两文件一致。

### 二、社区翻译贡献机制（`a9abb3c`）
- `CONTRIBUTING.md`：面向社区的翻译贡献指南（术语表扩充 / 翻译同步增量 / 审计翻漏三条路径 + 认领方式 + 自检）。
- `scripts/sync-worklist.mjs`：按上游 `base..upstream/main` 生成可认领的**翻译增量工作清单**，稳定内容的既有译文跨同步保留。
- `scripts/audit-coverage.mjs`：翻译覆盖审计（剥离不可翻译区后量化英文残留，advisory）。
- `research/english-coverage.md`：翻译覆盖分析报告（两种英文残留 + 术语表差距 + 建议）。
- `README.md`：新增「参与改进翻译（Contributing）」一节。

## 验证

- `node scripts/check-translation.mjs` 通过（exit 0）。
- `scripts/audit-coverage.mjs` 与 `scripts/sync-worklist.mjs` 均实测通过。

## 已推迟（不在本 PR 内）

- skill 文件内联链接到术语表。
- 按术语表逐处修正现有文件中的不一致（翻译补齐）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
