### PR TITLE
fix: restore upstream English display_name in agents/openai.yaml

### DIFF
--- a/skills/engineering/ask-matt/agents/openai.yaml
+++ b/skills/engineering/ask-matt/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "询问 Matt"
+  display_name: "Ask Matt"
   short_description: "找到合适的 skill 或 workflow"
 policy:
   allow_implicit_invocation: false

--- a/skills/engineering/code-review/agents/openai.yaml
+++ b/skills/engineering/code-review/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "代码审查"
+  display_name: "Code Review"
   short_description: "按规范和 spec 审查 diff"

--- a/skills/engineering/codebase-design/agents/openai.yaml
+++ b/skills/engineering/codebase-design/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "代码库设计"
+  display_name: "Codebase Design"
   short_description: "用于 deep-module 设计的词汇"

--- a/skills/engineering/diagnosing-bugs/agents/openai.yaml
+++ b/skills/engineering/diagnosing-bugs/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "诊断缺陷"
+  display_name: "Diagnosing Bugs"
   short_description: "诊断棘手缺陷和回退"

--- a/skills/engineering/domain-modeling/agents/openai.yaml
+++ b/skills/engineering/domain-modeling/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "领域建模"
+  display_name: "Domain Modeling"
   short_description: "构建并打磨领域模型"

--- a/skills/engineering/grill-with-docs/agents/openai.yaml
+++ b/skills/engineering/grill-with-docs/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "带文档追问"
+  display_name: "Grill with Docs"
   short_description: "追问设计并编写相关文档"
 policy:
   allow_implicit_invocation: false

--- a/skills/engineering/implement/agents/openai.yaml
+++ b/skills/engineering/implement/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "实现"
+  display_name: "Implement"
   short_description: "基于 spec 或 tickets 构建工作"
 policy:
   allow_implicit_invocation: false

--- a/skills/engineering/improve-codebase-architecture/agents/openai.yaml
+++ b/skills/engineering/improve-codebase-architecture/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "改进代码库架构"
+  display_name: "Improve Codebase Architecture"
   short_description: "寻找并追问架构改进机会"
 policy:
   allow_implicit_invocation: false

--- a/skills/engineering/prototype/agents/openai.yaml
+++ b/skills/engineering/prototype/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "原型"
+  display_name: "Prototype"
   short_description: "通过原型回答设计问题"

--- a/skills/engineering/research/agents/openai.yaml
+++ b/skills/engineering/research/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "调研"
+  display_name: "Research"
   short_description: "使用高可信来源调研"

--- a/skills/engineering/resolving-merge-conflicts/agents/openai.yaml
+++ b/skills/engineering/resolving-merge-conflicts/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "解决合并冲突"
+  display_name: "Resolving Merge Conflicts"
   short_description: "解决 merge 和 rebase conflicts"

--- a/skills/engineering/setup-matt-pocock-skills/agents/openai.yaml
+++ b/skills/engineering/setup-matt-pocock-skills/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "配置 Matt Pocock Skills"
+  display_name: "Setup Matt Pocock Skills"
   short_description: "为 skills 配置仓库"
 policy:
   allow_implicit_invocation: false

--- a/skills/engineering/to-spec/agents/openai.yaml
+++ b/skills/engineering/to-spec/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "转为 Spec"
+  display_name: "To Spec"
   short_description: "把对话转成 spec"
 policy:
   allow_implicit_invocation: false

--- a/skills/engineering/to-tickets/agents/openai.yaml
+++ b/skills/engineering/to-tickets/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "拆分为 Tickets"
+  display_name: "To Tickets"
   short_description: "把计划拆成 tracer-bullet tickets"
 policy:
   allow_implicit_invocation: false

--- a/skills/engineering/triage/agents/openai.yaml
+++ b/skills/engineering/triage/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "分诊"
+  display_name: "Triage"
   short_description: "按 triage roles 推进 issues"
 policy:
   allow_implicit_invocation: false

--- a/skills/engineering/wayfinder/agents/openai.yaml
+++ b/skills/engineering/wayfinder/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "寻路"
+  display_name: "Wayfinder"
   short_description: "把大型工作绘制成 decision tickets"
 policy:
   allow_implicit_invocation: false

--- a/skills/engineering/wizard/agents/openai.yaml
+++ b/skills/engineering/wizard/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "向导"
+  display_name: "Wizard"
   short_description: "生成交互式配置向导"

--- a/skills/in-progress/claude-handoff/agents/openai.yaml
+++ b/skills/in-progress/claude-handoff/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "Claude 交接"
+  display_name: "Claude Handoff"
   short_description: "把工作交给后台 agent"
 policy:
   allow_implicit_invocation: false

--- a/skills/in-progress/loop-me/agents/openai.yaml
+++ b/skills/in-progress/loop-me/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "循环访谈我"
+  display_name: "Loop Me"
   short_description: "为你要构建的 workflows 编写 spec"
 policy:
   allow_implicit_invocation: false

--- a/skills/in-progress/setup-ts-deep-modules/agents/openai.yaml
+++ b/skills/in-progress/setup-ts-deep-modules/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "配置 TS Deep Modules"
+  display_name: "Setup TS Deep Modules"
   short_description: "强制执行 deep TypeScript modules"
 policy:
   allow_implicit_invocation: false

--- a/skills/in-progress/writing-beats/agents/openai.yaml
+++ b/skills/in-progress/writing-beats/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "写作节拍"
+  display_name: "Writing Beats"
   short_description: "把原始素材组装成节拍"
 policy:
   allow_implicit_invocation: false

--- a/skills/in-progress/writing-fragments/agents/openai.yaml
+++ b/skills/in-progress/writing-fragments/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "写作片段"
+  display_name: "Writing Fragments"
   short_description: "挖掘原始写作片段"
 policy:
   allow_implicit_invocation: false

--- a/skills/in-progress/writing-shape/agents/openai.yaml
+++ b/skills/in-progress/writing-shape/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "塑造文章"
+  display_name: "Writing Shape"
   short_description: "把原始素材塑造成文章"
 policy:
   allow_implicit_invocation: false

--- a/skills/misc/git-guardrails-claude-code/agents/openai.yaml
+++ b/skills/misc/git-guardrails-claude-code/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "Claude Code Git 护栏"
+  display_name: "Git Guardrails for Claude Code"
   short_description: "阻止危险的 git commands"

--- a/skills/misc/migrate-to-shoehorn/agents/openai.yaml
+++ b/skills/misc/migrate-to-shoehorn/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "迁移到 Shoehorn"
+  display_name: "Migrate to Shoehorn"
   short_description: "用 shoehorn 替换测试断言"

--- a/skills/misc/scaffold-exercises/agents/openai.yaml
+++ b/skills/misc/scaffold-exercises/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "搭建练习脚手架"
+  display_name: "Scaffold Exercises"
   short_description: "搭建可通过 lint 的课程练习"

--- a/skills/misc/setup-pre-commit/agents/openai.yaml
+++ b/skills/misc/setup-pre-commit/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "配置 Pre-Commit"
+  display_name: "Setup Pre-Commit"
   short_description: "添加提交前质量检查"

--- a/skills/productivity/grill-me/agents/openai.yaml
+++ b/skills/productivity/grill-me/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "追问我"
+  display_name: "Grill Me"
   short_description: "通过访谈打磨计划"
 policy:
   allow_implicit_invocation: false

--- a/skills/productivity/grilling/agents/openai.yaml
+++ b/skills/productivity/grilling/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "持续追问"
+  display_name: "Grilling"
   short_description: "每次一轮问题地对思路做压力测试"

--- a/skills/productivity/handoff/agents/openai.yaml
+++ b/skills/productivity/handoff/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "交接"
+  display_name: "Handoff"
   short_description: "把对话压缩成交接文档"
 policy:
   allow_implicit_invocation: false

--- a/skills/productivity/teach/agents/openai.yaml
+++ b/skills/productivity/teach/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "教学"
+  display_name: "Teach"
   short_description: "在引导式 workspace 中学习概念"
 policy:
   allow_implicit_invocation: false

--- a/skills/productivity/to-questionnaire/agents/openai.yaml
+++ b/skills/productivity/to-questionnaire/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "转为 Questionnaire"
+  display_name: "To Questionnaire"
   short_description: "把问题预先整理成供他人回答的文档"
 policy:
   allow_implicit_invocation: false

--- a/skills/productivity/wait-what/agents/openai.yaml
+++ b/skills/productivity/wait-what/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "等一下"
+  display_name: "Wait What"
   short_description: "重新表述一遍——更简单，带上我缺失的 context"
 policy:
   allow_implicit_invocation: false

--- a/skills/productivity/writing-for-agents/agents/openai.yaml
+++ b/skills/productivity/writing-for-agents/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
-  display_name: "为 agent 写作"
+  display_name: "Writing for Agents"
   short_description: "编写 agent 消费的文档"


### PR DESCRIPTION
Codex 把 `display_name` 用作斜杠命令名，导致 `/grill-me` 显示成 `/追问我`。本 PR 将全部 34 个被翻译的 `display_name` 恢复为上游英文值（Title Case），`short_description` 保持中文本地化。

## 关联 issues

- Closes #28
- Related #22 —— 跟进项：在 TRANSLATE_GLOSSARY.md / translate-skill 中加规则：`openai.yaml` 的 `display_name` 不翻译，防止回归（建议并入 #22 的分支）